### PR TITLE
2.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+# 11 Dec 2022
+
+Added support for generating trace builds by using the `--trace` flag.
+
+Added type guards for the built-in `ImplementsShape` and `IsDerivedFromTemplate` methods.
+
+Added a new `copyEntities` option to `twconfig.json` that, when specified, will add any XML file in the project's src directory to the build output, allowing unsupported entities to be included in the extension.
+
+Fixed incorrect code generation when specifying default values for service parameters.
+
 # 21 May 2022
 
 Improved the error messages that appear when declaring a service parameter with certain unsupported types. ([stefan-lacatus](https://github.com/stefan-lacatus))

--- a/README.md
+++ b/README.md
@@ -18,7 +18,8 @@ There are many advantages to this, and here are some of them:
  * **Developer friendly**: Creating entities in thingworx isn't very comfortable for developers. Common features found in IDEs, such as finding references, project-wide searching for code and even having multiple services open at the same time are not really possible. Since this project is just a typescript project, you can make use of all of your IDE's features.
  * **Typescript features**: You can also make use of typescript features that don't exist in thingworx, such as creating and using interfaces, marking methods and properties as private and using newer javascript features that can be transpiled. Note that some of these are erased on the Thingworx side, but they can nevertheless be useful while developing.
  * **Separate development and runtime**: In thingworx, any change happens immediately and can affect the system. When using this project template, you have to first build & publish your updated code for it to take effect.
- * **Debug support**: By using the `ThingworxVSCodeDebugger` visual studio code extension and the `BMDebugServer` thingworx extension, developers can also debug their thingworx typescript projects directly from visual studio code. The debugger supports most common features including setting breakpoints, exception breakpoints, stepping, evaluating expressions and changing variable values. For more information about setting up debugging, see [Usage Guide](https://github.com/BogdanMihaiciuc/ThingworxVSCodeDebugger/wiki/Usage-Guide)
+ * **Debug support**: By using the `ThingworxVSCodeDebugger` visual studio code extension and the `BMDebugServer` thingworx extension, developers can also debug their thingworx typescript projects directly from visual studio code. The debugger supports most common features including setting breakpoints, exception breakpoints, stepping, evaluating expressions and changing variable values. For more information about setting up debugging, see [Usage Guide](https://github.com/BogdanMihaiciuc/ThingworxVSCodeDebugger/wiki/Usage-Guide).
+ * **Profiling support**: By using the `BMProfiler` thingworx extension, developers can also profile their thingworx typescript projects to quickly identify performance bottlenecks. The profiler is a simple tracing profiler that shows the amount of time spent executing each service or function within a service. The profiler generates reports that can be viewed in the chrome performance inspector. For more information about setting up profiling, see [BMProfiler](https://github.com/BogdanMihaiciuc/BMProfiler).
  * **Additional features**: The transformer also supports some additional features not directly available in Thingworx that make development easier such as providing useful constants like `METHOD_NAME`, giving developers the ability to declare and use global functions, writing inline SQL queries on Database things and extending data shapes.
 
 # Development
@@ -40,7 +41,7 @@ In order to develop with this project you need to do the following:
 2. Copy `.env.sample` to `.env` and configure the `THINGWORX_SERVER` and either `THINGWORX_USER` and `THINGWORX_PASSWORD` or `THINGWORX_APP_KEY` and other fields as needed.
 3. Open `package.json` and `twconfig.json` and change the fields as needed.
 4. Run `npm install`. This will install the development dependencies for the project.
-5. Run `npm run watch:declarations`. This will start a background process that is needed for generating certain files. **Don't forget this as compilation can fail if the generated files become stale.**
+5. Run `npm run watch:declarations`. This will start a background process that is needed for generating certain files.
 6. Start working on the project.
 
 ## Entity Dependencies
@@ -118,6 +119,10 @@ Deployment to Thingworx is part of the build process as explained above. Alterna
 
 For a complete changelog see [CHANGELOG.md](CHANGELOG.md).
 
+## 11 Dec 2022
+- Support for trace builds
+- Support for XML entities
+
 ## 2 May 2022
 
 - Support for inline SQL
@@ -139,10 +144,6 @@ For a complete changelog see [CHANGELOG.md](CHANGELOG.md).
 - Support for multiple projects
 - Support for SQL services
 - Support for using environment variables in configuration table values
-
-## 28 Dec 2021
-
-- Support for creating debug builds.
 
 # Credit/Acknowledgment
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,16 @@
 {
 	"name": "bm-thingworx-vscode",
-	"version": "2.5.5",
+	"version": "2.6.0",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "bm-thingworx-vscode",
-			"version": "2.5.5",
+			"version": "2.6.0",
 			"license": "MIT",
 			"devDependencies": {
-				"@types/node": "^8.10.11",
-				"bm-thing-cli": "^1.4.5"
+				"@types/node": "8.10.11",
+				"bm-thing-cli": "^1.5.0"
 			}
 		},
 		"../ThingCLI": {
@@ -35,9 +35,9 @@
 			}
 		},
 		"node_modules/@types/node": {
-			"version": "8.10.52",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-8.10.52.tgz",
-			"integrity": "sha512-2RbW7WXeLex6RI+kQSxq6Ym0GiVcODeQ4Km7MnnTX5BHdOGQnqVa+s6AUmAW+OFYAJ8wv9QxvNZXm7/kBdGTVw==",
+			"version": "8.10.11",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-8.10.11.tgz",
+			"integrity": "sha512-FM7tvbjbn2BUzM/Qsdk9LUGq3zeh7li8NcHoS398dBzqLzfmSqSP1+yKbMRTCcZzLcu2JAR5lq3IKIEYkto7iQ==",
 			"dev": true
 		},
 		"node_modules/adm-zip": {
@@ -59,13 +59,13 @@
 			}
 		},
 		"node_modules/bm-thing-cli": {
-			"version": "1.4.5",
-			"resolved": "https://registry.npmjs.org/bm-thing-cli/-/bm-thing-cli-1.4.5.tgz",
-			"integrity": "sha512-XrDT3XoMegSzQ62FkeYSYwnTACBfhrhul3b14EznZ930BdS4kVDYxEhVHTIQfPsZdpt4Md1ylEKU6V6I+gIPew==",
+			"version": "1.5.0",
+			"resolved": "https://registry.npmjs.org/bm-thing-cli/-/bm-thing-cli-1.5.0.tgz",
+			"integrity": "sha512-bf3VmNQxuIAtoDI5Enx4r8mm8QI5edHsW8xgLMNRiWkUbqmfn/PH6iiRWDOnGUBfSU81ypiwhBJYgoZYhcjH/A==",
 			"dev": true,
 			"dependencies": {
 				"adm-zip": "0.5.9",
-				"bm-thing-transformer": "1.4.5",
+				"bm-thing-transformer": "1.5.0",
 				"dotenv": "^16.0.0",
 				"enquirer": "^2.3.6",
 				"typescript": "4.6.3",
@@ -76,9 +76,9 @@
 			}
 		},
 		"node_modules/bm-thing-transformer": {
-			"version": "1.4.5",
-			"resolved": "https://registry.npmjs.org/bm-thing-transformer/-/bm-thing-transformer-1.4.5.tgz",
-			"integrity": "sha512-Uo4NHdsuDjOxU4mJZhWCFAE19dHfhB3j4tiRN2m5OFT+jrB1pT3oIUiEqY+N5pmMmgQTl74v/PmkBgUD7413Xg==",
+			"version": "1.5.0",
+			"resolved": "https://registry.npmjs.org/bm-thing-transformer/-/bm-thing-transformer-1.5.0.tgz",
+			"integrity": "sha512-5UQgtkLg3MUpm8057iCk7Jt9Y9O/CuQ+4VX+9Hsn7qvT9CR2l9e5iDN5CnSOZIFv7UEvkvBKrCk3Bl3RbW2waw==",
 			"dev": true,
 			"dependencies": {
 				"typescript": "4.6.3",
@@ -150,9 +150,9 @@
 	},
 	"dependencies": {
 		"@types/node": {
-			"version": "8.10.52",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-8.10.52.tgz",
-			"integrity": "sha512-2RbW7WXeLex6RI+kQSxq6Ym0GiVcODeQ4Km7MnnTX5BHdOGQnqVa+s6AUmAW+OFYAJ8wv9QxvNZXm7/kBdGTVw==",
+			"version": "8.10.11",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-8.10.11.tgz",
+			"integrity": "sha512-FM7tvbjbn2BUzM/Qsdk9LUGq3zeh7li8NcHoS398dBzqLzfmSqSP1+yKbMRTCcZzLcu2JAR5lq3IKIEYkto7iQ==",
 			"dev": true
 		},
 		"adm-zip": {
@@ -168,13 +168,13 @@
 			"dev": true
 		},
 		"bm-thing-cli": {
-			"version": "1.4.5",
-			"resolved": "https://registry.npmjs.org/bm-thing-cli/-/bm-thing-cli-1.4.5.tgz",
-			"integrity": "sha512-XrDT3XoMegSzQ62FkeYSYwnTACBfhrhul3b14EznZ930BdS4kVDYxEhVHTIQfPsZdpt4Md1ylEKU6V6I+gIPew==",
+			"version": "1.5.0",
+			"resolved": "https://registry.npmjs.org/bm-thing-cli/-/bm-thing-cli-1.5.0.tgz",
+			"integrity": "sha512-bf3VmNQxuIAtoDI5Enx4r8mm8QI5edHsW8xgLMNRiWkUbqmfn/PH6iiRWDOnGUBfSU81ypiwhBJYgoZYhcjH/A==",
 			"dev": true,
 			"requires": {
 				"adm-zip": "0.5.9",
-				"bm-thing-transformer": "1.4.5",
+				"bm-thing-transformer": "1.5.0",
 				"dotenv": "^16.0.0",
 				"enquirer": "^2.3.6",
 				"typescript": "4.6.3",
@@ -182,9 +182,9 @@
 			}
 		},
 		"bm-thing-transformer": {
-			"version": "1.4.5",
-			"resolved": "https://registry.npmjs.org/bm-thing-transformer/-/bm-thing-transformer-1.4.5.tgz",
-			"integrity": "sha512-Uo4NHdsuDjOxU4mJZhWCFAE19dHfhB3j4tiRN2m5OFT+jrB1pT3oIUiEqY+N5pmMmgQTl74v/PmkBgUD7413Xg==",
+			"version": "1.5.0",
+			"resolved": "https://registry.npmjs.org/bm-thing-transformer/-/bm-thing-transformer-1.5.0.tgz",
+			"integrity": "sha512-5UQgtkLg3MUpm8057iCk7Jt9Y9O/CuQ+4VX+9Hsn7qvT9CR2l9e5iDN5CnSOZIFv7UEvkvBKrCk3Bl3RbW2waw==",
 			"dev": true,
 			"requires": {
 				"typescript": "4.6.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "bm-thingworx-vscode",
-	"version": "2.5.5",
+	"version": "2.6.0",
 	"description": "Develop in ThingWorx with a proper IDE.",
 	"author": "Thingworx RoIcenter",
 	"thingworxProjectName": "MyProject",
@@ -32,7 +32,7 @@
 		"LICENSE"
 	],
 	"devDependencies": {
-		"@types/node": "^8.10.11",
-		"bm-thing-cli": "^1.4.5"
+		"@types/node": "8.10.11",
+		"bm-thing-cli": "^1.5.0"
 	}
 }


### PR DESCRIPTION
Added support for generating trace builds by using the `--trace` flag.

Added type guards for the built-in `ImplementsShape` and `IsDerivedFromTemplate` methods.

Added a new `copyEntities` option to `twconfig.json` that, when specified, will add any XML file in the project's src directory to the build output, allowing unsupported entities to be included in the extension.

Fixed incorrect code generation when specifying default values for service parameters.